### PR TITLE
fix: install nexus service unit on AL2023

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -131,7 +131,7 @@
     owner: root
     group: root
     mode: 0755
-  when: ansible_distribution_major_version == '6'
+  when: ansible_service_mgr != 'systemd'
   tags: ['nexus3']
 
 - name: place nexus systemd service unit
@@ -141,8 +141,8 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_distribution_major_version == '7'
-  notify: 
+  when: ansible_service_mgr == 'systemd'
+  notify:
     - reload systemd
     - restart nexus
   tags: ['nexus3']


### PR DESCRIPTION
## What

Gate the nexus service install on `ansible_service_mgr` instead of hardcoded distribution major versions:

- init.d link: `when: ansible_distribution_major_version == '6'` → `when: ansible_service_mgr != 'systemd'`
- systemd unit: `when: ansible_distribution_major_version == '7'` → `when: ansible_service_mgr == 'systemd'`

## Why

The compat `set_fact` block only maps Amazon Linux `"NA"→6` and `"2"→7`. On Amazon Linux 2023, `ansible_distribution_major_version` is `"2023"`, so it matched **neither** the `'6'` (init.d) nor `'7'` (systemd) branch. As a result no service unit was placed and the subsequent `ensure the nexus service has started` task failed.

Gating on `ansible_service_mgr` is robust across AL2, AL2023, and EL: the systemd unit is installed wherever systemd is the init system, init.d otherwise.

## Compatibility

No behavior change on AL2 (systemd) or older init.d systems — same outcome as before, just selected by the actual service manager rather than an OS-version proxy. Targets a `v0.3.0` release.

## How to test

Run the role on an AL2023 host and confirm `/etc/systemd/system/nexus.service` is created and `systemctl status nexus` shows the service started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)