### PR TITLE
fix: explicitly create nexus group

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,9 +8,17 @@
   when: ansible_distribution == "Amazon" and ansible_distribution_major_version == "2"
   tags: ['nexus3']
 
+- name: ensure nexus group exists
+  group:
+    name: "{{ nexus_user }}"
+    state: present
+    system: true
+  tags: ['nexus3']
+
 - name: ensure nexus user exists
   user:
     name: "{{ nexus_user }}"
+    group: "{{ nexus_user }}"
     state: present
     system: true
   tags: ['nexus3']


### PR DESCRIPTION
The role created the nexus user but relied on useradd auto-creating a same-named private group. On AL2023 that group is not created, so every task referencing group "nexus" (starting with the /opt/nexus chgrp) failed with "failed to look up group nexus". Create the group explicitly and set it as the user's primary group.